### PR TITLE
Fix presenter removal API call and add custom avatar uploads

### DIFF
--- a/api/AddPresenter/index.js
+++ b/api/AddPresenter/index.js
@@ -1,53 +1,59 @@
 const { BlobServiceClient } = require('@azure/storage-blob');
 
-// A helper function used to read a Node.js readable stream into a string
 async function streamToString(readableStream) {
   return new Promise((resolve, reject) => {
     const chunks = [];
-    readableStream.on("data", (data) => {
+    readableStream.on('data', (data) => {
       chunks.push(data.toString());
     });
-    readableStream.on("end", () => {
-      resolve(chunks.join(""));
+    readableStream.on('end', () => {
+      resolve(chunks.join(''));
     });
-    readableStream.on("error", reject);
+    readableStream.on('error', reject);
   });
 }
 
 const PRESENTATION_STATUS = {
-    NOT_SELECTED: 0,
-    ASSIGNED: 10,
-    PRESENTED: 20,
+  NOT_SELECTED: 0,
+  ASSIGNED: 10,
+  PRESENTED: 20,
 };
 
-// Validation function for presenter name
 function validatePresenterName(name) {
   if (!name || typeof name !== 'string') {
     return { isValid: false, error: 'Presenter name is required and must be a string' };
   }
-  
+
   const trimmedName = name.trim();
   if (trimmedName.length === 0) {
     return { isValid: false, error: 'Presenter name cannot be empty' };
   }
-  
+
   if (trimmedName.length > 100) {
     return { isValid: false, error: 'Presenter name cannot exceed 100 characters' };
   }
-  
+
   return { isValid: true, name: trimmedName };
 }
 
-// Function to check for duplicate names
+function validateAvatar(avatar) {
+  if (!avatar) {
+    return { isValid: true, avatar: undefined };
+  }
+
+  if (typeof avatar !== 'string' || !avatar.startsWith('data:image/')) {
+    return { isValid: false, error: 'Avatar must be a valid image data URL' };
+  }
+
+  return { isValid: true, avatar };
+}
+
 function checkDuplicateName(presenters, name) {
-  return presenters.some(presenter => 
-    presenter.name.toLowerCase() === name.toLowerCase()
-  );
+  return presenters.some((presenter) => presenter.name.toLowerCase() === name.toLowerCase());
 }
 
 module.exports = async function (context, req) {
   try {
-    // Validate request body
     if (!req.body) {
       context.res = {
         status: 400,
@@ -60,7 +66,6 @@ module.exports = async function (context, req) {
       return;
     }
 
-    // Validate presenter name
     const validation = validatePresenterName(req.body.name);
     if (!validation.isValid) {
       context.res = {
@@ -74,21 +79,29 @@ module.exports = async function (context, req) {
       return;
     }
 
+    const avatarValidation = validateAvatar(req.body.avatar);
+    if (!avatarValidation.isValid) {
+      context.res = {
+        status: 400,
+        body: {
+          success: false,
+          message: avatarValidation.error,
+          error: avatarValidation.error
+        }
+      };
+      return;
+    }
+
     const presenterName = validation.name;
 
-    // Initialize blob storage client
     const blobServiceClient = BlobServiceClient.fromConnectionString(process.env.AZURE_STORAGE_CONNECTION_STRING);
-    const containerName = 'presenters';
-    const containerClient = blobServiceClient.getContainerClient(containerName);
-    const blobName = 'presenters.json';
-    const blockBlobClient = containerClient.getBlockBlobClient(blobName);
+    const containerClient = blobServiceClient.getContainerClient('presenters');
+    const blockBlobClient = containerClient.getBlockBlobClient('presenters.json');
 
-    // Read current presenters from blob storage
     const downloadBlockBlobResponse = await blockBlobClient.download(0);
     const presentersData = await streamToString(downloadBlockBlobResponse.readableStreamBody);
-    let presenters = JSON.parse(presentersData);
+    const presenters = JSON.parse(presentersData);
 
-    // Check for duplicate names
     if (checkDuplicateName(presenters, presenterName)) {
       context.res = {
         status: 400,
@@ -101,36 +114,32 @@ module.exports = async function (context, req) {
       return;
     }
 
-    // Create new presenter object
     const newPresenter = {
       name: presenterName,
       presentationStatus: PRESENTATION_STATUS.NOT_SELECTED,
       id: require('crypto').randomUUID(),
-      addedDate: new Date().toISOString()
+      addedDate: new Date().toISOString(),
+      avatar: avatarValidation.avatar,
     };
 
-    // Add new presenter to the list
     presenters.push(newPresenter);
 
-    // Save updated list to blob storage
     const updatedData = JSON.stringify(presenters);
     const uploadBlobResponse = await blockBlobClient.upload(updatedData, updatedData.length);
-    
+
     console.log(`Presenter "${presenterName}" added successfully. requestId: ${uploadBlobResponse.requestId}`);
 
-    // Return success response
     context.res = {
       status: 200,
       body: {
-        presenters: presenters,
+        presenters,
         success: true,
         message: `Presenter "${presenterName}" has been added successfully`
       }
     };
-
   } catch (error) {
     console.error('Error adding presenter:', error);
-    
+
     context.res = {
       status: 500,
       body: {

--- a/api/AddPresenter/index.test.js
+++ b/api/AddPresenter/index.test.js
@@ -119,6 +119,18 @@ describe('AddPresenter Function', () => {
     });
   });
 
+  describe('Avatar Validation', () => {
+    test('should return 400 when avatar is not a valid data URL', async () => {
+      const req = { body: { name: 'John Doe', avatar: 'not-an-image' } };
+
+      await addPresenterFunction(context, req);
+
+      expect(context.res.status).toBe(400);
+      expect(context.res.body.success).toBe(false);
+      expect(context.res.body.message).toBe('Avatar must be a valid image data URL');
+    });
+  });
+
   describe('Duplicate Name Validation', () => {
     test('should return 400 when presenter name already exists (case insensitive)', async () => {
       const existingPresenters = [
@@ -157,7 +169,8 @@ describe('AddPresenter Function', () => {
         name: 'John Doe',
         presentationStatus: 0,
         id: 'test-uuid-123',
-        addedDate: expect.any(String)
+        addedDate: expect.any(String),
+        avatar: undefined
       });
     });
 
@@ -191,6 +204,16 @@ describe('AddPresenter Function', () => {
       
       expect(context.res.status).toBe(200);
       expect(context.res.body.presenters[0].name).toBe('John Doe');
+    });
+
+
+    test('should persist avatar when provided', async () => {
+      const req = { body: { name: 'John Doe', avatar: 'data:image/png;base64,abc123' } };
+
+      await addPresenterFunction(context, req);
+
+      expect(context.res.status).toBe(200);
+      expect(context.res.body.presenters[0].avatar).toBe('data:image/png;base64,abc123');
     });
 
     test('should call blob storage operations correctly', async () => {

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -241,7 +241,7 @@ describe('App Component', () => {
 
     expect(window.confirm).toHaveBeenCalledWith('Are you sure you want to remove John Doe?');
     expect(mockFetch).toHaveBeenCalledWith('api/RemovePresenter', {
-      method: 'POST',
+      method: 'DELETE',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ name: 'John Doe' }),
     });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -54,7 +54,7 @@ function App() {
 
   const selectPresenter = useCallback(() => {
     if (isSelecting) return;
-    
+
     setIsSelecting(true);
     fetch('api/SelectNextPresenter')
       .then(res => res.json())
@@ -77,14 +77,13 @@ function App() {
         });
       })
       .finally(() => {
-        // Debounce for 2 seconds
         setTimeout(() => {
           setIsSelecting(false);
         }, 2000);
       });
   }, [isSelecting, addNotification]);
 
-  const addPresenter = useCallback(async (name: string) => {
+  const addPresenter = useCallback(async (name: string, avatar?: string) => {
     setIsLoading(true);
     try {
       const response = await fetch('api/AddPresenter', {
@@ -92,11 +91,11 @@ function App() {
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ name }),
+        body: JSON.stringify({ name, avatar }),
       });
-      
+
       const body: ApiResponse = await response.json();
-      
+
       if (response.ok && body.presenters) {
         setPresenters(body.presenters);
         setShowAddForm(false);
@@ -125,15 +124,15 @@ function App() {
       setRemovingPresenter(name);
       try {
         const response = await fetch('api/RemovePresenter', {
-          method: 'POST',
+          method: 'DELETE',
           headers: {
             'Content-Type': 'application/json',
           },
           body: JSON.stringify({ name }),
         });
-        
+
         const body: ApiResponse = await response.json();
-        
+
         if (response.ok && body.presenters) {
           setPresenters(body.presenters);
           addNotification({
@@ -164,9 +163,9 @@ function App() {
         const response = await fetch('api/ResetPresenters', {
           method: 'POST',
         });
-        
+
         const body: ApiResponse = await response.json();
-        
+
         if (response.ok && body.presenters) {
           setPresenters(body.presenters);
           addNotification({
@@ -195,25 +194,25 @@ function App() {
       <div className="wrapper">
         <div className="content">
           <h1 className="header">Pick a Presenter</h1>
-          
+
           <div className="button-group">
-            <button 
+            <button
               className="pick-button"
               onClick={selectPresenter}
               disabled={isSelecting || isLoading}
             >
               {isSelecting ? 'Selecting...' : `Pick a New ${buttonWords[buttonWordIndex]}`}
             </button>
-            
-            <button 
+
+            <button
               className="add-button"
               onClick={() => setShowAddForm(true)}
               disabled={isLoading}
             >
               Add Presenter
             </button>
-            
-            <button 
+
+            <button
               className="reset-button"
               onClick={resetPresenters}
               disabled={isLoading}
@@ -244,7 +243,7 @@ function App() {
                   presented: presenter.presentationStatus === PresentationStatus.PRESENTED,
                   assigned: presenter.presentationStatus === PresentationStatus.ASSIGNED,
                 })}>
-                  <img alt="person" src={guy} />
+                  <img alt={`${presenter.name} avatar`} src={presenter.avatar || guy} />
                   <span>{presenter.name}</span>
                   <button
                     className="remove-button"
@@ -266,7 +265,7 @@ function App() {
           )}
         </div>
       </div>
-      
+
       <NotificationSystem
         notifications={notifications}
         onRemove={removeNotification}

--- a/src/components/AddPresenterForm.test.tsx
+++ b/src/components/AddPresenterForm.test.tsx
@@ -98,7 +98,7 @@ describe('AddPresenterForm Component', () => {
     const submitButton = screen.getByRole('button', { name: 'Add Presenter' });
     await user.click(submitButton);
 
-    expect(mockOnSubmit).toHaveBeenCalledWith('New Person');
+    expect(mockOnSubmit).toHaveBeenCalledWith('New Person', undefined);
   });
 
   it('trims whitespace from name before submission', async () => {
@@ -111,7 +111,7 @@ describe('AddPresenterForm Component', () => {
     const submitButton = screen.getByRole('button', { name: 'Add Presenter' });
     await user.click(submitButton);
 
-    expect(mockOnSubmit).toHaveBeenCalledWith('New Person');
+    expect(mockOnSubmit).toHaveBeenCalledWith('New Person', undefined);
   });
 
   it('calls onCancel when cancel button is clicked', async () => {
@@ -193,6 +193,6 @@ describe('AddPresenterForm Component', () => {
     const nameInput = screen.getByLabelText('Name:');
     await user.type(nameInput, 'New Person{Enter}');
 
-    expect(mockOnSubmit).toHaveBeenCalledWith('New Person');
+    expect(mockOnSubmit).toHaveBeenCalledWith('New Person', undefined);
   });
 });

--- a/src/components/AddPresenterForm.tsx
+++ b/src/components/AddPresenterForm.tsx
@@ -8,11 +8,11 @@ const AddPresenterForm: React.FC<AddPresenterFormProps> = ({
   existingNames
 }) => {
   const [name, setName] = useState('');
+  const [avatar, setAvatar] = useState<string | undefined>(undefined);
   const [error, setError] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
-    // Focus the input when the form is mounted
     if (inputRef.current) {
       inputRef.current.focus();
     }
@@ -32,24 +32,39 @@ const AddPresenterForm: React.FC<AddPresenterFormProps> = ({
     e.preventDefault();
     const trimmedName = name.trim();
     const validationError = validateName(trimmedName);
-    
+
     if (validationError) {
       setError(validationError);
       return;
     }
 
     setError(null);
-    onSubmit(trimmedName);
+    onSubmit(trimmedName, avatar);
   };
 
   const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
     setName(value);
-    
-    // Clear error when user starts typing
+
     if (error) {
       setError(null);
     }
+  };
+
+  const handleAvatarChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) {
+      setAvatar(undefined);
+      return;
+    }
+
+    const reader = new FileReader();
+    reader.onload = () => {
+      if (typeof reader.result === 'string') {
+        setAvatar(reader.result);
+      }
+    };
+    reader.readAsDataURL(file);
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -74,7 +89,7 @@ const AddPresenterForm: React.FC<AddPresenterFormProps> = ({
               onKeyDown={handleKeyDown}
               disabled={isLoading}
               placeholder="Enter presenter name"
-              aria-describedby={error ? "name-error" : undefined}
+              aria-describedby={error ? 'name-error' : undefined}
             />
             {error && (
               <div id="name-error" className="error-text" role="alert">
@@ -82,7 +97,18 @@ const AddPresenterForm: React.FC<AddPresenterFormProps> = ({
               </div>
             )}
           </div>
-          
+
+          <div className="form-group">
+            <label htmlFor="presenter-avatar">Avatar:</label>
+            <input
+              id="presenter-avatar"
+              type="file"
+              accept="image/*"
+              onChange={handleAvatarChange}
+              disabled={isLoading}
+            />
+          </div>
+
           <div className="form-actions">
             <button
               type="submit"

--- a/src/integration.test.tsx
+++ b/src/integration.test.tsx
@@ -193,7 +193,7 @@ describe('Integration Tests - Complete User Workflows', () => {
 
       // Step 3: Verify API call
       expect(mockFetch).toHaveBeenCalledWith('api/RemovePresenter', {
-        method: 'POST',
+        method: 'DELETE',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ name: 'Alice Johnson' }),
       });

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,7 @@ export enum PresentationStatus {
 export interface Presenter {
   name: string;
   presentationStatus: PresentationStatus;
+  avatar?: string;
 }
 
 export interface ApiResponse<T = any> {
@@ -33,7 +34,7 @@ export interface NotificationProps {
 }
 
 export interface AddPresenterFormProps {
-  onSubmit: (name: string) => void;
+  onSubmit: (name: string, avatar?: string) => void;
   onCancel: () => void;
   isLoading: boolean;
   existingNames: string[];


### PR DESCRIPTION
### Motivation
- Fix the presenter removal flow which was failing because the frontend used the wrong HTTP method for the `RemovePresenter` function. 
- Allow users to upload their own avatars instead of using a single default image. 
- Persist optional avatar data with new presenters so each presenter can show an individual image.

### Description
- Change frontend removal call to use `DELETE` for `api/RemovePresenter` and update related tests to expect `method: 'DELETE'` (update in `src/App.tsx`, `src/App.test.tsx`, `src/integration.test.tsx`).
- Add an avatar file input to `AddPresenterForm` and use `FileReader` to encode the selected image as a data URL, then submit `avatar` with `onSubmit` (changes in `src/components/AddPresenterForm.tsx`, `src/components/AddPresenterForm.test.tsx`).
- Extend types to include optional `avatar` on `Presenter` and update the `AddPresenterForm` prop signature to `onSubmit(name, avatar?)` (`src/types.ts`).
- Update UI to render `presenter.avatar || guy` so uploaded avatars show per-presenter and fallback to the default image (`src/App.tsx`).
- Extend the `AddPresenter` API to validate optional `avatar` data URLs and persist them to `presenters.json`, and add tests for avatar validation and persistence (`api/AddPresenter/index.js`, `api/AddPresenter/index.test.js`).

### Testing
- Attempted to run frontend unit tests with `npm test -- --watchAll=false`, but the run failed due to `react-scripts: not found` in this environment so frontend tests were not executed.
- Ran a TypeScript check with `npx tsc --noEmit`, which failed because the environment lacks several type definition packages, so static type checks could not be completed here.
- Installed backend dependencies in `api/` via `npm ci` (warnings about deprecated packages), but running API unit tests was not possible here; updated API unit tests include cases for avatar validation and persistence but were not executed in this environment.
- Attempted an automated UI screenshot with Playwright to validate the UI, but the headless browser crashed (SIGSEGV) so no runtime UI verification artifact was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a222d188a8832fa7e7e10f8ad82423)