### PR TITLE
Add clickable presenter avatar upload

### DIFF
--- a/src/App.avatar.test.tsx
+++ b/src/App.avatar.test.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import App from './App';
+import { PresentationStatus } from './types';
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+describe('App avatar upload', () => {
+  const mockPresenters = [
+    { name: 'John Doe', presentationStatus: PresentationStatus.NOT_SELECTED },
+  ];
+
+  beforeEach(() => {
+    mockFetch.mockReset();
+    mockFetch.mockResolvedValue({
+      ok: true,
+      text: async () => JSON.stringify({ presenters: mockPresenters }),
+    });
+
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      value: jest.fn(() => 'blob:avatar-url'),
+    });
+
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      configurable: true,
+      value: jest.fn(),
+    });
+  });
+
+  it('allows selecting a custom avatar by clicking the presenter image', async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByText('John Doe')).toBeInTheDocument();
+    });
+
+    const avatarButton = screen.getByRole('button', { name: 'Change avatar for John Doe' });
+    await user.click(avatarButton);
+
+    const avatarInput = document.querySelector('input.avatar-input') as HTMLInputElement;
+    expect(avatarInput).toBeInTheDocument();
+
+    const file = new File(['avatar'], 'avatar.png', { type: 'image/png' });
+    fireEvent.change(avatarInput, { target: { files: [file] } });
+
+    expect(URL.createObjectURL).toHaveBeenCalledWith(file);
+
+    await waitFor(() => {
+      const updatedAvatar = screen.getByAltText('John Doe avatar') as HTMLImageElement;
+      expect(updatedAvatar.src).toContain('blob:avatar-url');
+    });
+  });
+});

--- a/src/App.css
+++ b/src/App.css
@@ -130,6 +130,30 @@ body {
   height: auto;
 }
 
+
+.avatar-button {
+  background: transparent;
+  border: none;
+  padding: 0;
+  width: 100%;
+  cursor: pointer;
+}
+
+.avatar-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
+.avatar-button img {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.avatar-input {
+  display: none;
+}
+
 .assigned {
   background: url('./assets/spotlight.png');
   background-size: 100% 100%;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ const parseApiResponse = async (response: Response): Promise<ApiResponse> => {
 
 function App() {
   const [presenters, setPresenters] = useState<Presenter[]>([]);
+  const [avatarUrls, setAvatarUrls] = useState<Record<string, string>>({});
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
   const [isSelecting, setIsSelecting] = useState<boolean>(false);
@@ -29,6 +30,7 @@ function App() {
 
   const [notifications, setNotifications] = useState<NotificationProps[]>([]);
   const [removingPresenter, setRemovingPresenter] = useState<string | null>(null);
+  const fileInputRefs = React.useRef<Record<string, HTMLInputElement | null>>({});
 
   const addNotification = useCallback((notification: Omit<NotificationProps, 'id'>) => {
     const id = Date.now().toString();
@@ -61,6 +63,37 @@ function App() {
         setIsLoading(false);
       });
   }, [addNotification]);
+
+  useEffect(() => {
+    setAvatarUrls(prev => {
+      const activeNames = new Set(presenters.map(presenter => presenter.name));
+      const staleNames = Object.keys(prev).filter(name => !activeNames.has(name));
+
+      if (staleNames.length === 0) {
+        return prev;
+      }
+
+      const next = { ...prev };
+      staleNames.forEach(name => {
+        if (next[name].startsWith('blob:')) {
+          URL.revokeObjectURL(next[name]);
+        }
+        delete next[name];
+      });
+
+      return next;
+    });
+  }, [presenters]);
+
+  useEffect(() => {
+    return () => {
+      Object.values(avatarUrls).forEach(url => {
+        if (url.startsWith('blob:')) {
+          URL.revokeObjectURL(url);
+        }
+      });
+    };
+  }, [avatarUrls]);
 
   const selectPresenter = useCallback(() => {
     if (isSelecting) return;
@@ -204,6 +237,42 @@ function App() {
     }
   }, [addNotification]);
 
+  const openAvatarPicker = useCallback((name: string) => {
+    fileInputRefs.current[name]?.click();
+  }, []);
+
+  const updateAvatar = useCallback((name: string, file?: File) => {
+    if (!file) {
+      return;
+    }
+
+    if (!file.type.startsWith('image/')) {
+      addNotification({
+        type: 'error',
+        message: 'Please choose a valid image file for your avatar.'
+      });
+      return;
+    }
+
+    const newUrl = URL.createObjectURL(file);
+    setAvatarUrls(prev => {
+      const currentUrl = prev[name];
+      if (currentUrl?.startsWith('blob:')) {
+        URL.revokeObjectURL(currentUrl);
+      }
+
+      return {
+        ...prev,
+        [name]: newUrl,
+      };
+    });
+
+    addNotification({
+      type: 'success',
+      message: `${name}'s avatar has been updated.`
+    });
+  }, [addNotification]);
+
   return (
     <div className="App">
       <div className="wrapper">
@@ -258,7 +327,28 @@ function App() {
                   presented: presenter.presentationStatus === PresentationStatus.PRESENTED,
                   assigned: presenter.presentationStatus === PresentationStatus.ASSIGNED,
                 })}>
-                  <img alt="person" src={guy} />
+                  <button
+                    type="button"
+                    className="avatar-button"
+                    onClick={() => openAvatarPicker(presenter.name)}
+                    disabled={isLoading}
+                    aria-label={`Change avatar for ${presenter.name}`}
+                    title={`Change avatar for ${presenter.name}`}
+                  >
+                    <img alt={`${presenter.name} avatar`} src={avatarUrls[presenter.name] || guy} />
+                  </button>
+                  <input
+                    ref={element => {
+                      fileInputRefs.current[presenter.name] = element;
+                    }}
+                    className="avatar-input"
+                    type="file"
+                    accept="image/*"
+                    onChange={e => {
+                      updateAvatar(presenter.name, e.target.files?.[0]);
+                      e.target.value = '';
+                    }}
+                  />
                   <span>{presenter.name}</span>
                   <button
                     className="remove-button"


### PR DESCRIPTION
### Motivation
- Let users click their presenter image to choose and preview a custom avatar so each presenter can show a personalized photo instead of the default image.

### Description
- Add `avatarUrls` state and `fileInputRefs` to `src/App.tsx` and wire a hidden file input per presenter with an `avatar-button` that opens the file picker when clicked.
- Implement `updateAvatar` to validate image MIME type, create object URLs via `URL.createObjectURL`, update the displayed avatar immediately, and show success/error notifications.
- Revoke object URLs for replaced/stale avatars and on component unmount to avoid memory leaks.
- Add styling in `src/App.css` for `.avatar-button` and `.avatar-input` to keep the UI consistent and hide the native file input.
- Add a focused test `src/App.avatar.test.tsx` that mocks `fetch` and `URL.createObjectURL` and verifies the click → file selection → preview flow.

### Testing
- Ran the scoped test `npm test -- --watchAll=false App.avatar.test.tsx`, which passed successfully. 
- Ran the full test suite `npm test -- --watchAll=false`, which shows unrelated existing integration-test failures in this repository and is _not_ caused by these changes. 
- Built the app with `npm run build`, which completed successfully and produced an optimized production build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a23cdf7504832fbf6cd2881201f5e2)